### PR TITLE
Infinite loop correction and TestFDP parameters check

### DIFF
--- a/src/FDP/FDP.c
+++ b/src/FDP/FDP.c
@@ -370,7 +370,7 @@ FDP_EXPORTED
 bool FDP_ReadVirtualMemory(FDP_SHM* pFDP, uint32_t CpuId, uint8_t* pDstBuffer, uint32_t ReadSize,
                            uint64_t VirtualAddress)
 {
-    if (pFDP == NULL)
+    if (pFDP == NULL || ReadSize <= 0)
     {
         return false;
     }

--- a/src/TestFDP/TestFDP.c
+++ b/src/TestFDP/TestFDP.c
@@ -1774,6 +1774,18 @@ int testFDP(char *pVMName) {
 }
 
 
-void main(int argc, char *argv[]){
-    testFDP(argv[1]);
+void usage(char * binPath){
+    printf("Usage: %s [VM Name]\n", binPath);
+}
+
+int main(int argc, char *argv[]){
+    if (argc != 2){
+        usage(argv[0]);
+        return 2;
+    }
+
+    if (testFDP(argv[1]))
+        return 0;
+    else
+        return 1;
 }


### PR DESCRIPTION
Two corrections: 
- Infinite loop when reading virtual memory with size equal or less than 0
- Check parameters in TestFDP and add usage 